### PR TITLE
Mark TabError as noqa to silence linters on Python 3

### DIFF
--- a/mixed_tabs_and_spaces.py
+++ b/mixed_tabs_and_spaces.py
@@ -1,7 +1,7 @@
 def square(x):
     sum_so_far = 0
-    for counter in range(x):
-        sum_so_far = sum_so_far + x
-	return sum_so_far  # noqa: E999 # pylint: disable=bad-indentation Python 3 will raise a TabError here
+    for _ in range(x):
+        sum_so_far += x
+	return sum_so_far  # noqa: E999 # pylint: disable=mixed-indentation Python 3 will raise a TabError here
 
 print(square(10))

--- a/mixed_tabs_and_spaces.py
+++ b/mixed_tabs_and_spaces.py
@@ -2,6 +2,6 @@ def square(x):
     sum_so_far = 0
     for counter in range(x):
         sum_so_far = sum_so_far + x
-	return sum_so_far  # noqa Python 3 will raise a TabError here
+	return sum_so_far  # noqa: E999 # pylint: disable=bad-indentation Python 3 will raise a TabError here
 
 print(square(10))

--- a/mixed_tabs_and_spaces.py
+++ b/mixed_tabs_and_spaces.py
@@ -2,6 +2,6 @@ def square(x):
     sum_so_far = 0
     for counter in range(x):
         sum_so_far = sum_so_far + x
-	return sum_so_far
+	return sum_so_far  # noqa Python 3 will raise a TabError here
 
 print(square(10))


### PR DESCRIPTION
flake8 testing of https://github.com/satwikkansal/wtfpython on Python 3.6.2

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./mixed_tabs_and_spaces.py:5:18: E999 TabError: inconsistent use of tabs and spaces in indentation
	return sum_so_far
                 ^
```