### PR TITLE
Fix typo, expression output True and not [[...]]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1648,7 +1648,7 @@ a, b = a[b] = {}, 5
   >>> some_list[0]
   [[...]]
   >>> some_list is some_list[0]
-  [[...]]
+  True
   ```
   Similar is the case in our example (`a[b][0]` is the same object as `a`)
 


### PR DESCRIPTION
Just a minor typo.

On a cyclic list, ```some_list is some_list[0]``` return  ```True``` and not ```[[...]]```