### PR TITLE
Added a new Example: Sets discriminating values?

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,16 +296,16 @@ True
 * But why did the `is` operator evaluated to `False`? Let's see with this snippet.
   ```py
   class WTF(object):
-    def __init__(self): print("I ")
-    def __del__(self): print("D ")
+    def __init__(self): print("I", end = " ")
+    def __del__(self): print("D", end = " ")
   ```
 
   **Output:**
   ```py
   >>> WTF() is WTF()
-  I I D D
+  I I D D False
   >>> id(WTF()) == id(WTF())
-  I D I D
+  I D I D True
   ```
   As you may observe, the order in which the objects are destroyed is what made all the difference here.
 

--- a/README.md
+++ b/README.md
@@ -1260,6 +1260,58 @@ The built-in `ord()` function returns a character's Unicode [code point](https:/
 
 ---
 
+ ### ▶ Sets discriminating values? *
+
+ ```py
+ >>> st = set()
+ >>> st.add(5)
+ >>> st.add(5)
+ >>> st.add(10)
+ >>> st.add(10)
+ >>> st.add(10)
+ >>> st.add(20)
+ >>> st.add(2)
+ >>> st.add(345678)
+ >>> st1 = set(sorted(st))
+ ```
+
+ **Output:**
+ ```py
+ >>> st
+ {2, 5, 10, 345678, 20}
+ >>> st1
+ {2, 5, 10, 345678, 20}
+ ```
+ Everything looks pretty sorted ... just why are sets messing up with 345678?
+
+
+ #### 💡 Explanation:
+
+ * This is because a set object is "an unordered collection" of distinct objects.
+ * So values in a set object are not in a sorted way. Even the values 2, 5, 10 and 20 aren't inserted in sorted manner.
+   
+   ```py
+   >>> st = set()
+   >>> st.add(5)
+   >>> st.add(10)
+   >>> print(st)
+   >>> st.add(20)
+   >>> print(st)
+   >>> st.add(2)
+   >>> print(st)
+   >>> st.add(345678)
+   >>> print(st)
+   ```
+   **Output:**
+   ```py
+   {10, 5}
+   {10, 20, 5}
+   {10, 2, 20, 5}
+   {2, 5, 10, 345678, 20}
+   ```
+   **Note:** This is why when we want to iterate on the distinct elements of a sequence in sorted way, we iterate on the list obtained from sorted(st), not on the set itself.
+---
+
 ### ▶ Teleportation *
 
 ```py

--- a/README.md
+++ b/README.md
@@ -296,16 +296,24 @@ True
 * But why did the `is` operator evaluated to `False`? Let's see with this snippet.
   ```py
   class WTF(object):
-    def __init__(self): print("I", end = " ")
-    def __del__(self): print("D", end = " ")
+    def __init__(self): print("I")
+    def __del__(self): print("D")
   ```
 
   **Output:**
   ```py
   >>> WTF() is WTF()
-  I I D D False
+  I
+  I
+  D
+  D
+  False
   >>> id(WTF()) == id(WTF())
-  I D I D True
+  I
+  D
+  I
+  D
+  True
   ```
   As you may observe, the order in which the objects are destroyed is what made all the difference here.
 


### PR DESCRIPTION
**Section**: [Appearences are deceptive!](https://github.com/satwikkansal/wtfpython#section-appearances-are-deceptive)
(Open to any recommendations to add it to another section)

**Link** (not yet added in the table of contents):  [Sets discriminating values?](https://github.com/Vibhu-Agarwal/wtfpython#-sets-discriminating-values-)

**Concept**: A set object in python never sorts its values by itself in any specific order.

The example illustrates that somehow an odd value is left off from being sorted by set.
The explanation clarifies that indeed neither of any values are being sorted.

Every sample is tested on 3.6.6 interactive interpreter and they should work for all the Python versions