### PR TITLE
Adds wemake-python-styleguide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2438,6 +2438,7 @@ The idea and design for this collection were initially inspired by Denys Dovhan'
 * https://stackoverflow.com/questions/1011431/common-pitfalls-in-python
 * https://www.python.org/doc/humor/
 * https://www.codementor.io/satwikkansal/python-practices-for-efficient-code-performance-memory-and-usability-aze6oiq65
+* https://github.com/wemake-services/wemake-python-styleguide
 
 # 🎓 License
 


### PR DESCRIPTION
`wemake-python-styleguide` is the strictest python linter out there.
It was partially inspired by this project. And we have implemented almost rules as automatic checks from the examples. References: https://github.com/wemake-services/wemake-python-styleguide/search?q=wtfpython&type=Issues

It is a `flake8` plugin with some extra goodies, it can be used as `flake8 .` or like so:
![Github Action](https://raw.githubusercontent.com/wemake-services/wemake-python-styleguide/master/docs/_static/reviewdog.png)

Link: https://github.com/wemake-services/wemake-python-styleguide
Docs: https://wemake-python-stylegui.de/en/latest/