### PR TITLE
Make sure that default_arg is not passed rather than checking for fal…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2173,7 +2173,7 @@ def some_func(default_arg=[]):
 
     ```py
     def some_func(default_arg=None):
-        if not default_arg:
+        if default_arg is not None:
             default_arg = []
         default_arg.append("some_string")
         return default_arg


### PR DESCRIPTION
…sity

```
if not default_arg:
    ...
```
fails when `default_arg` can be assigned and still be false (implementing a `__bool__` or `__len__` etc). You dont want to overwrite the passed values.