### PR TITLE
Fix explanation for 6th example of "Needles in a Haystack"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2579,7 +2579,7 @@ def similar_recursive_func(a):
 
 * As for the fifth snippet, most methods that modify the items of sequence/mapping objects like `list.append`, `dict.update`, `list.sort`, etc. modify the objects in-place and return `None`. The rationale behind this is to improve performance by avoiding making a copy of the object if the operation can be done in-place (Referred from [here](http://docs.python.org/2/faq/design.html#why-doesn-t-list-sort-return-the-sorted-list)).
 
-* Last one should be fairly obvious, passing mutable object (like  `list` ) results in a call by reference, whereas an immutable object (like `int`)  results in a call by value.
+* Last one should be fairly obvious, mutable object (like `list`) can be altered in the function, and the reassignation of an immutable (`a -= 1`) is not an alteration of the value.
 
 * Being aware of these nitpicks can save you hours of debugging effort in the long run. 
 


### PR DESCRIPTION
Remove the sentence about call by reference / value and replacete it by an explanation about reassignation.

closes #163 