### PR TITLE
Extend the explanation of the "is not ..." section

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,7 +933,7 @@ False
 #### 💡 Explanation
 
 - `is not` is a single binary operator, and has behavior different than using `is` and `not` separated.
-- `is not` evaluates to `False` if the variables on either side of the operator point to the same object and `True` otherwise.
+- `is not` evaluates to `False` if the variables on either side of the operator point to the same object and `True` otherwise. In this expression, `(not None)` evaluates to `True`, since `None` is is `False` in a boolean context, so the expression becomes `'something' is True`.
 
 ---
 


### PR DESCRIPTION
I thought that the explanation for "'something' is (not None)" could
be a little more explicit.