### PR TITLE
Fixed logic error in "Beware of default mutable arguments!"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2241,7 +2241,7 @@ def some_func(default_arg=[]):
 
     ```py
     def some_func(default_arg=None):
-        if default_arg is not None:
+        if default_arg is None:
             default_arg = []
         default_arg.append("some_string")
         return default_arg


### PR DESCRIPTION
The example showing how using None as a default argument is used
instead of a mutable default argument had reversed logic.  It would
set default_arg to [] whenever the caller passed a non-None argument.