### PR TITLE
Add "bloating instance dicts" section

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,7 +21,7 @@ Following are the wonderful people (in no specific order) who have contributed t
 | Ghost account | N/A | [#96](https://github.com/satwikkansal/wtfpython/issues/96)
 | koddo | [koddo](https://github.com/koddo) | [#80](https://github.com/satwikkansal/wtfpython/issues/80), [#73](https://github.com/satwikkansal/wtfpython/issues/73) |
 | jab | [jab](https://github.com/jab) | [#77](https://github.com/satwikkansal/wtfpython/issues/77) |
-| Jongy | [Jongy](https://github.com/Jongy) | [#208](https://github.com/satwikkansal/wtfpython/issues/208) |
+| Jongy | [Jongy](https://github.com/Jongy) | [#208](https://github.com/satwikkansal/wtfpython/issues/208), [#210](https://github.com/satwikkansal/wtfpython/issues/210) |
 ---
 
 **Translations**

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ So, here we go...
   * [Section: Miscellaneous](#section-miscellaneous)
     + [▶ `+=` is faster](#--is-faster)
     + [▶ Let's make a giant string!](#-lets-make-a-giant-string)
-    + [▶ Slowing down `dict` lookups *](#-slowing-down-dict-lookups)
+    + [▶ Slowing down `dict` lookups *](#-slowing-down-dict-lookups-)
     + [▶ Bloating instance `dict`s *](#-bloating-instance-dicts-)
     + [▶ Minor Ones *](#-minor-ones-)
 - [Contributing](#contributing)


### PR DESCRIPTION
I tested on Python 3.6, 3.7 and 3.8. On Python 3.5, sizes do not change - which suggests 3.5 doesn't have key sharing, although it did have, I think (the PEP was introduced between 3.3 and 3.4). And Python 2 is irrelevant, of course.

Closes: #210