### PR TITLE
Improve string indexing result explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3554,7 +3554,7 @@ What makes those dictionaries become bloated? And why are newly created objects 
   
 * Few weird looking but semantically correct statements:
   + `[] = ()` is a semantically correct statement (unpacking an empty `tuple` into an empty `list`)
-  + `'a'[0][0][0][0][0]` is also a semantically correct statement as strings are [sequences](https://docs.python.org/3/glossary.html#term-sequence)(iterables supporting element access using integer indices) in Python.
+  + `'a'[0][0][0][0][0]` is also semantically correct, because Python doesn't have a character data type like other languages branched from C. So selecting a single character from a string returns a single-character string.
   + `3 --0-- 5 == 8` and `--5 == 5` are both semantically correct statements and evaluate to `True`.
 
 * Given that `a` is a number, `++a` and `--a` are both valid Python statements but don't behave the same way as compared with similar statements in languages like C, C++, or Java.


### PR DESCRIPTION
The ideia is pretty much improve the explanation of why `'a'[0][0][0][0][0]` is syntactically correct.