### PR TITLE
Add Spanish translation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -33,6 +33,7 @@ Following are the wonderful people (in no specific order) who have contributed t
 |-------------|--------|--------|
 | leisurelicht | [leisurelicht](https://github.com/leisurelicht) | [Chinese](https://github.com/leisurelicht/wtfpython-cn) |
 | vuduclyunitn | [vuduclyunitn](https://github.com/vuduclyunitn) | [Vietnamese](https://github.com/vuduclyunitn/wtfptyhon-vi) |
+| José De Freitas | [JoseDeFreitas](https://github.com/JoseDeFreitas) | [Spanish](https://github.com/JoseDeFreitas/wtfpython-es) |
 
 
 Thank you all for your time and making wtfpython more awesome! :smile:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <h1 align="center">What the f*ck Python! 😱</h1>
 <p align="center">Exploring and understanding Python through surprising snippets.</p>
 
-Translations: [Chinese 中文](https://github.com/leisurelicht/wtfpython-cn) | [Vietnamese Tiếng Việt](https://github.com/vuduclyunitn/wtfptyhon-vi) | [Add translation](https://github.com/satwikkansal/wtfpython/issues/new?title=Add%20translation%20for%20[LANGUAGE]&body=Expected%20time%20to%20finish:%20[X]%20weeks.%20I%27ll%20start%20working%20on%20it%20from%20[Y].)
+Translations: [Chinese 中文](https://github.com/leisurelicht/wtfpython-cn) | [Vietnamese Tiếng Việt](https://github.com/vuduclyunitn/wtfptyhon-vi) | [Spanish Español](https://github.com/JoseDeFreitas/wtfpython-es) | [Add translation](https://github.com/satwikkansal/wtfpython/issues/new?title=Add%20translation%20for%20[LANGUAGE]&body=Expected%20time%20to%20finish:%20[X]%20weeks.%20I%27ll%20start%20working%20on%20it%20from%20[Y].)
 
 Other modes: [Interactive](https://colab.research.google.com/github/satwikkansal/wtfpython/blob/master/irrelevant/wtf.ipynb) | [CLI](https://pypi.python.org/pypi/wtfpython)
 


### PR DESCRIPTION
Hello @satwikkansal!

Refer to issue: #252. I've finished the Spanish translation (wrote 1 week on the issue but it turns out I'm a few days late 😅). Nonetheless, the translation is completed.

**Things I did:**
- Translated all content from English to Spanish from the files `README.md`, `CONTRIBUTING.md` and `CONTRIBUTORS.md`.
- Replaced some links with its Spanish translation mirror (most docs.python.org links and some wikipedia links).
- Translate **only** the comments from the code snippets.

The repository: [JoseDeFreitas/wtfpython-es](https://github.com/JoseDeFreitas/wtfpython-es) (on `master` branch).

**This pull request:**
- Added the reference in the [README.md](https://github.com/satwikkansal/wtfpython/blob/master/README.md) file.
- Added myself in the [CONTRIBUTORS.md](https://github.com/satwikkansal/wtfpython/blob/master/CONTRIBUTORS.md) file.

I'll be watching the changes in this repository from time to time so I can update the Spanish translation.