### PR TITLE
Update link and add parenthesis to chained operators section

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,15 +384,15 @@ False
 
 #### 💡 Explanation:
 
-As per https://docs.python.org/3/reference/expressions.html#membership-test-operations
+As per https://docs.python.org/3/reference/expressions.html#comparisons
 
 > Formally, if a, b, c, ..., y, z are expressions and op1, op2, ..., opN are comparison operators, then a op1 b op2 c ... y opN z is equivalent to a op1 b and b op2 c and ... y opN z, except that each expression is evaluated at most once.
 
 While such behavior might seem silly to you in the above examples, it's fantastic with stuff like `a == b == c` and `0 <= x <= 100`.
 
 * `False is False is False` is equivalent to `(False is False) and (False is False)`
-* `True is False == False` is equivalent to `True is False and False == False` and since the first part of the statement (`True is False`) evaluates to `False`, the overall expression evaluates to `False`.
-* `1 > 0 < 1` is equivalent to `1 > 0 and 0 < 1` which evaluates to `True`.
+* `True is False == False` is equivalent to `(True is False) and (False == False)` and since the first part of the statement (`True is False`) evaluates to `False`, the overall expression evaluates to `False`.
+* `1 > 0 < 1` is equivalent to `(1 > 0) and (0 < 1)` which evaluates to `True`.
 * The expression `(1 > 0) < 1` is equivalent to `True < 1` and
   ```py
   >>> int(True)


### PR DESCRIPTION
Update the link to Python docs that was incorrect, and adds parenthesis that makes the conditional statements easier to understand.